### PR TITLE
[BUG] fix horizontal scroll issue

### DIFF
--- a/projects/ngx-pull-to-refresh/src/lib/ngx-pull-to-refresh.component.scss
+++ b/projects/ngx-pull-to-refresh/src/lib/ngx-pull-to-refresh.component.scss
@@ -12,11 +12,14 @@ $transition-duration: 200ms;
   min-height:100%;
   // overflow:hidden;
   position: relative;
+  overscroll-behavior-x: auto;
   overscroll-behavior-y: contain;
 
   &.horizontal {
     overflow-x: auto;
-	overflow-y: hidden;
+	  overflow-y: hidden;
+    overscroll-behavior-x: contain;
+    overscroll-behavior-y: auto;
   }
 }
 


### PR DESCRIPTION
When `overscroll-behavior: contain` set, it always take the scroll action even overflow sets `auto`.
---
`overscroll-hehavior: contain`이 설정됐을때에는 overflow를 `auto`로 설정하여도 항상 스크롤 이벤트를 가져가는 버그 수정