### PR TITLE
Don't load font and overwrite body/html styling with it

### DIFF
--- a/projects/ngx-pull-to-refresh/src/lib/ngx-pull-to-refresh.component.scss
+++ b/projects/ngx-pull-to-refresh/src/lib/ngx-pull-to-refresh.component.scss
@@ -1,5 +1,3 @@
-@import url(https://fonts.googleapis.com/css?family=Lato:700);
-
 $class-prefix: "ngx-ptr";
 $transition-duration: 200ms;
 
@@ -48,17 +46,6 @@ $transition-duration: 200ms;
   text-align:center;
   justify-content: center;
 }
-
-
-html,
-body {
-  background: #ecf0f1;
-  color: #444;
-  font-family: 'Lato', Tahoma, Geneva, sans-serif;
-  font-size: 16px;
-  padding: 10px;
-}
-
 
 $offset: 187;
 $duration: 1.4s;


### PR DESCRIPTION
Currently the component loads the `Lato` from Google and tries to apply it to the `body` and `html`.

A component shouldn't overwrite global styling and due to scoping this doesn't work anyway, so I removed it.

This also makes it not error when used on internal websites.